### PR TITLE
imp: recebe username como input

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ Stryker evaluator action for Tryber projects
 
 This action evaluate Tryber projects with [Stryker](https://www.npmjs.com/package/stryker) library.
 
+## Inputs
+
+- `pr_author_username`
+
+  **Required**
+
+  Pull Request author username.
+
 ## Outputs
 
 ### `result`

--- a/README.md
+++ b/README.md
@@ -14,21 +14,25 @@ This action evaluate Tryber projects with [Stryker](https://www.npmjs.com/packag
 
 ## Outputs
 
-### `result`
+- `result`
 
-Stryker unit tests JSON results in base64 format.
+  Stryker unit tests JSON results in base64 format.
 
 ## Usage example
 
 ```yml
-- uses: betrybe/stryker-evaluator-action@v2
+- uses: betrybe/stryker-evaluator-action@v3
+  with:
+    pr_author_username: ${{ github.event.inputs.pr_author_username }}
 ```
 
 ## How to get result output
 ```yml
 - name: Stryker evaluator
   id: evaluator
-  uses: betrybe/stryker-evaluator-action@v2
+  uses: betrybe/stryker-evaluator-action@v3
+  with:
+    pr_author_username: ${{ github.event.inputs.pr_author_username }}
 - name: Next step
   uses: another-github-action
   with:

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,9 @@
 name: 'Stryker evaluator'
 description: 'Stryker evaluator action for Tryber projects'
+inputs:
+  pr_author_username:
+    description: 'Pull Request author username'
+    required: true
 outputs:
   result:
     description: 'Stryker unit tests JSON results in base64 format.'

--- a/evaluator.js
+++ b/evaluator.js
@@ -5,7 +5,7 @@ const destinyPath = 'result.json';
 const CORRECT_ANSWER_GRADE = 3;
 const WRONG_ANSWER_GRADE = 1;
 
-const githubUsername = process.env.GITHUB_ACTOR || 'no_actor';
+const githubUsername = process.env.INPUT_PR_AUTHOR_USERNAME || 'no_actor';
 const githubRepositoryName = process.env.GITHUB_REPOSITORY || 'no_repository';
 
 const requirementName = process.argv[2].split('/')[2].split('.')[0] + ' mutation test';


### PR DESCRIPTION
Devido as alterações na [LEARN-869](https://trybe.atlassian.net/browse/LEARN-869?atlOrigin=eyJpIjoiNjk5MjBkZDIzNTM2NDY5NmExMGJjYmRjN2NlZDAzYjAiLCJwIjoiaiJ9) e como o _workflow_ é disparado via **Github App Selfhosted**, a envvar `GITHUB_ACTOR` não poderá ser usada para pegar o **username** da pessoa estudante. Além disso, o **número** da Pull Request não vem no contexto do evento da _action_. Foi modificado para estes dados serem enviados pelo Github App via _input_. Assim sendo, será necessário modificar os avaliadores para o novo formato.